### PR TITLE
2.0: Remove AsynchronousType

### DIFF
--- a/Form/WidgetListingType.php
+++ b/Form/WidgetListingType.php
@@ -93,13 +93,6 @@ class WidgetListingType extends WidgetType
                 'data-flag' => 'v-quantum-name',
             ],
         ]);
-        $builder->add('asynchronous', AsynchronousType::class, [
-            'label'    => 'victoire.widget.type.asynchronous.label',
-            'required' => false,
-            'attr'     => [
-                'class' => 'vic-col-xs-12',
-            ],
-        ]);
 
         //add the slot to the form
         $builder->add('slot', HiddenType::class);


### PR DESCRIPTION
AsynchronousType has been removed in Victoire 2.3.29: https://github.com/Victoire/victoire/releases/tag/2.3.29
QuantumType should be imported from parent form type