### PR TITLE
Hotfix: Use QuantumType only if it exists

### DIFF
--- a/Form/WidgetListingType.php
+++ b/Form/WidgetListingType.php
@@ -10,7 +10,6 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Victoire\Bundle\CoreBundle\Form\AsynchronousType;
-use Victoire\Bundle\CoreBundle\Form\QuantumType;
 use Victoire\Bundle\CoreBundle\Form\WidgetType;
 use Victoire\Bundle\WidgetBundle\Entity\Widget;
 
@@ -87,12 +86,14 @@ class WidgetListingType extends WidgetType
         $builder->add('mode', HiddenType::class, [
             'data' => $options['mode'],
         ]);
-        $builder->add('quantum', QuantumType::class, [
-            'label'    => 'victoire.widget.type.quantum.label',
-            'attr'     => [
-                'data-flag' => 'v-quantum-name',
-            ],
-        ]);
+        if (class_exists('Victoire\Bundle\CoreBundle\Form\QuantumType')) {
+            $builder->add('quantum', Victoire\Bundle\CoreBundle\Form\QuantumType::class, [
+                'label'    => 'victoire.widget.type.quantum.label',
+                'attr'     => [
+                    'data-flag' => 'v-quantum-name',
+                ],
+            ]);
+        }
 
         //add the slot to the form
         $builder->add('slot', HiddenType::class);


### PR DESCRIPTION
Error:

> Could not load type "Victoire\Widget\ListingBundle\Form\Victoire\Bundle\CoreBundle\Form\QuantumType"
> 500 Internal Server Error - InvalidArgumentException 

`QuantumType` was added in Victoire 2.3: https://github.com/Victoire/victoire/commit/9b4892ca8e6849e0c80043b9abfaa0181d2e46f8#diff-9898783acd00646c600142a34381633c

It breaks this widget on Victoire 2.2. This patch fixes this error by using `QuantumType` only if the class exists.