### PR TITLE
Fix wrong namespace with victoire 2.3

### DIFF
--- a/Form/WidgetListingType.php
+++ b/Form/WidgetListingType.php
@@ -86,8 +86,8 @@ class WidgetListingType extends WidgetType
         $builder->add('mode', HiddenType::class, [
             'data' => $options['mode'],
         ]);
-        if (class_exists('Victoire\Bundle\CoreBundle\Form\QuantumType')) {
-            $builder->add('quantum', Victoire\Bundle\CoreBundle\Form\QuantumType::class, [
+        if (class_exists('\Victoire\Bundle\CoreBundle\Form\QuantumType')) {
+            $builder->add('quantum', \Victoire\Bundle\CoreBundle\Form\QuantumType::class, [
                 'label'    => 'victoire.widget.type.quantum.label',
                 'attr'     => [
                     'data-flag' => 'v-quantum-name',


### PR DESCRIPTION
Namespace was wrong in #28, this caused an issue with Victoire 2.3.

Error message was:
“Could not load type "Victoire\Widget\ListingBundle\Form\Victoire\Bundle\
CoreBundle\Form\QuantumType": class does not exist.”