### PR TITLE
Fix issue with Victoire 2.2 and 2.3

### DIFF
--- a/Form/WidgetListingType.php
+++ b/Form/WidgetListingType.php
@@ -10,6 +10,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Victoire\Bundle\CoreBundle\Form\AsynchronousType;
+use Victoire\Bundle\CoreBundle\Form\QuantumType;
 use Victoire\Bundle\CoreBundle\Form\WidgetType;
 use Victoire\Bundle\WidgetBundle\Entity\Widget;
 
@@ -86,14 +87,12 @@ class WidgetListingType extends WidgetType
         $builder->add('mode', HiddenType::class, [
             'data' => $options['mode'],
         ]);
-        if (class_exists('\Victoire\Bundle\CoreBundle\Form\QuantumType')) {
-            $builder->add('quantum', \Victoire\Bundle\CoreBundle\Form\QuantumType::class, [
-                'label'    => 'victoire.widget.type.quantum.label',
-                'attr'     => [
-                    'data-flag' => 'v-quantum-name',
-                ],
-            ]);
-        }
+        $builder->add('quantum', QuantumType::class, [
+            'label'    => 'victoire.widget.type.quantum.label',
+            'attr'     => [
+                'data-flag' => 'v-quantum-name',
+            ],
+        ]);
 
         //add the slot to the form
         $builder->add('slot', HiddenType::class);

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/framework-bundle": "~2.8|~3.0",
-        "victoire/victoire": ">=2.2.10|~3.0",
+        "victoire/victoire": ">=2.3|~3.0",
         "pagerfanta/pagerfanta": "^1.0@dev"
     },
     "autoload": {


### PR DESCRIPTION
Replaces #28 and #29.

We can't keep compatibility with Victoire 2.2 since this widget uses quantum: https://github.com/FriendsOfVictoire/WidgetListingBundle/blob/c204bbca087a06e1f42a179beb5047036ec95785/Resources/views/form.html.twig#L27

Quantum were introduced in [Victoire 2.3](https://github.com/Victoire/victoire/commit/9b4892ca8e6849e0c80043b9abfaa0181d2e46f8#diff-9898783acd00646c600142a34381633c), we should drop support of Victoire 2.2.
