### PR TITLE
 Fixes #24: Fix Javascript error with quantum 

### DIFF
--- a/Resources/views/form.html.twig
+++ b/Resources/views/form.html.twig
@@ -24,7 +24,7 @@
 
 {% block form_static %}
         {{ form_start(form) }}
-        <a href="#" onclick='addItemStaticForm("", {{ quantum }})' class="vic-btn vic-btn-add" class="vic-btn vic-btn-add add-request-block">{{ 'widget.form.WidgetListingItemType.addItem.label'|trans({}, 'victoire') }}</a>
+        <a href="#" onclick='addItemStaticForm("", "{{ quantum }}")' class="vic-btn vic-btn-add" class="vic-btn vic-btn-add add-request-block">{{ 'widget.form.WidgetListingItemType.addItem.label'|trans({}, 'victoire') }}</a>
         {# It could be simpler here but this is done in order to give an example to implementations with more complicated forms #}
         <ul class="vic-row vic-items" data-prototype="{% filter escape %}{% include 'VictoireWidgetListingBundle::_itemForm.html.twig' with { 'item': form.items.vars.prototype } %}{% endfilter %}">
             {% for item in form.items %}


### PR DESCRIPTION
Fixes #24 

There was a Javascript exception :

> file:1 Uncaught ReferenceError: a is not defined
>    at HTMLAnchorElement.onclick

Because quotes were missing around the Javascript variable `a`:

> &lt;a href='#' onclick='addItemStaticForm('"", a)' …